### PR TITLE
✏️Fixed typo in 15.4 in multiset example

### DIFF
--- a/linear_algebra/source/lecture15.tex
+++ b/linear_algebra/source/lecture15.tex
@@ -144,7 +144,7 @@ $U, W \subseteq V$ -- подпространства.
 \begin{example}
     Если $\E_1 = \{e_1, e_2\}, \E_2 = \{e_2, e_3\}$, то
     \begin{itemize}[nosep]
-    \item $\E_1 \cup \E_2 = \{e_1, e_2, e_3\}$ -- 2 элемента,
+    \item $\E_1 \cup \E_2 = \{e_1, e_2, e_3\}$ -- 3 элемента,
     \item $\E_1 \sqcup \E_2 = \{e_1, e_2, e_2, e_3\}$ -- 4 элемента.
     \end{itemize}
 \end{example}


### PR DESCRIPTION
Опечатка в примере мультимножеств. Должно быть 3 элемента, написано 2.